### PR TITLE
fix: configuration arguments conflict for protected branch

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ resource "gitlab_project_approval_rule" "default" {
   project                           = gitlab_project.default.id
   name                              = var.project_approval_rule.name
   approvals_required                = var.project_approval_rule.approvals_required
-  applies_to_all_protected_branches = var.project_approval_rule.applies_to_all_protected_branches
+  applies_to_all_protected_branches = try(var.project_approval_rule.protected_branches, null) == null ? var.project_approval_rule.applies_to_all_protected_branches : null
   protected_branch_ids              = try([for branch in var.project_approval_rule.protected_branches : gitlab_branch_protection.default[branch].branch_protection_id], null)
   user_ids                          = try(data.gitlab_user.project_approval_rule_users[*].id, null)
   group_ids                         = try(data.gitlab_group.project_approval_rule_groups[*].id, null)


### PR DESCRIPTION
fix
```
Planning failed. Terraform encountered an error while generating this plan.
╷
│ Error: Conflicting configuration arguments
│ 
│   with module.gitlab["xxxxx"].gitlab_project_approval_rule.default,
│   on .terraform/modules/gitlab/main.tf line 100, in resource "gitlab_project_approval_rule" "default":
│  100:   applies_to_all_protected_branches = var.project_approval_rule.applies_to_all_protected_branches
│ 
│ "applies_to_all_protected_branches": conflicts with protected_branch_ids

```